### PR TITLE
remove name/description, rename title to 'RFC Discussion'

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/RFC.yml
+++ b/.github/DISCUSSION_TEMPLATE/RFC.yml
@@ -1,6 +1,4 @@
-name: RFC Discussion
-description: "Template for submitting RFC proposals in the Genomic Data Infrastructure repository"
-title: "[RFC] <Title of Your RFC Proposal>"
+title: "[RFC Discussion] "
 labels: 
   - "RFC"
   - "discussion"


### PR DESCRIPTION
Fixes

![image](https://github.com/user-attachments/assets/ee27b073-ea14-4659-9eac-e756a95eb8c8)
